### PR TITLE
API周りを改善する

### DIFF
--- a/YumemiCodeCheck/ViewModels/ContentViewModel.swift
+++ b/YumemiCodeCheck/ViewModels/ContentViewModel.swift
@@ -13,7 +13,10 @@ final class ContentViewModel: ObservableObject {
     @Published var bloodType: Blood = .typeA
 
     @Published var prefecture: Prefecture?
+    @Published var errorType: PersonInputError?
     @Published var isLoading: Bool = false
+
+    @Published var isAlert: Bool = false
 
     let apiClient = YumemiAPIClient(urlSession: .shared, urlRequestBuilder: URLRequestBuilder())
 
@@ -21,18 +24,65 @@ final class ContentViewModel: ObservableObject {
         DispatchQueue.main.async {
             self.isLoading = true
         }
+
         do {
-            let request = Person(name: name, birthday: birthday, bloodType: bloodType)
+            // API通信
+            let request = try validatePerson()
             let response = try await apiClient.send(request)
             DispatchQueue.main.async {
                 self.prefecture = response
             }
+        } catch let personInputError as PersonInputError {
+            // Personに関するエラー処理
+            DispatchQueue.main.async {
+                self.errorType = personInputError
+                self.isAlert = true
+            }
         } catch {
-            // エラー処理
-            print("error")
+            // httpに関するエラー処理
+            if let httpError = error as? HTTPError {
+                DispatchQueue.main.async {
+                    self.errorType = .apiError
+                    self.isAlert = true
+                }
+            }
         }
+
         DispatchQueue.main.async {
             self.isLoading = false
         }
+    }
+}
+
+// MARK: - Alert
+
+extension ContentViewModel {
+    enum PersonInputError: LocalizedError {
+        case apiError
+        case nameEmptyError
+        case nameTooLongError   // nameが128字以上の場合
+
+        var errorDescription: String? {
+            switch self {
+            case .apiError:
+                return "通信エラーが発生しました"
+            case .nameEmptyError:
+                return "名前を入力してください"
+            case .nameTooLongError:
+                return "名前が長すぎます。\n128文字未満で入力してください。"
+            }
+        }
+    }
+
+    func validatePerson() throws -> Person {
+        guard !name.isEmpty else {
+            throw PersonInputError.nameEmptyError
+        }
+
+        guard name.count < 128 else {
+            throw PersonInputError.nameTooLongError
+        }
+
+        return Person(name: name, birthday: birthday, bloodType: bloodType)
     }
 }

--- a/YumemiCodeCheck/ViewModels/ContentViewModel.swift
+++ b/YumemiCodeCheck/ViewModels/ContentViewModel.swift
@@ -13,10 +13,14 @@ final class ContentViewModel: ObservableObject {
     @Published var bloodType: Blood = .typeA
 
     @Published var prefecture: Prefecture?
+    @Published var isLoading: Bool = false
 
     let apiClient = YumemiAPIClient(urlSession: .shared, urlRequestBuilder: URLRequestBuilder())
 
     func onTapFortuneTelling() async {
+        DispatchQueue.main.async {
+            self.isLoading = true
+        }
         do {
             let request = Person(name: name, birthday: birthday, bloodType: bloodType)
             let response = try await apiClient.send(request)
@@ -26,6 +30,9 @@ final class ContentViewModel: ObservableObject {
         } catch {
             // エラー処理
             print("error")
+        }
+        DispatchQueue.main.async {
+            self.isLoading = false
         }
     }
 }

--- a/YumemiCodeCheck/Views/ContentView.swift
+++ b/YumemiCodeCheck/Views/ContentView.swift
@@ -13,6 +13,7 @@ struct ContentView: View {
 
     var body: some View {
         PersonInputScreen(viewModel: viewModel)
+            .alert(isPresented: $viewModel.isAlert, error: viewModel.errorType, actions: {})
             .fullScreenCover(item: $viewModel.prefecture) { prefecture in
                 FortuneResultScreen(prefecture: prefecture)
             }

--- a/YumemiCodeCheck/Views/PersonInput/PersonInputScreen.swift
+++ b/YumemiCodeCheck/Views/PersonInput/PersonInputScreen.swift
@@ -26,9 +26,16 @@ struct PersonInputScreen: View {
                     await viewModel.onTapFortuneTelling()
                 }
             } label: {
-                Text("占う")
+                if viewModel.isLoading {
+                    ProgressView()
+                } else {
+                    Text("占う")
+                }
             }
-            .buttonStyle(RoundedRectangleButtonStyle(backgroundColor: .purple))
+            .disabled(viewModel.isLoading)
+            .buttonStyle(RoundedRectangleButtonStyle(
+                backgroundColor: viewModel.isLoading ? .purple.opacity(0.3) : .purple)
+            )
         }
         .padding(.horizontal, 30)
         .padding(.bottom, 16)

--- a/YumemiCodeCheck/Views/PersonInput/SubViews/PersonInputView.swift
+++ b/YumemiCodeCheck/Views/PersonInput/SubViews/PersonInputView.swift
@@ -16,11 +16,13 @@ struct PersonInputView: View {
             InputRowView(title: "名前") {
                 TextField("ここに入力", text: $viewModel.name)
                     .multilineTextAlignment(TextAlignment.trailing)
+                    .disabled(viewModel.isLoading)
                     .padding(.trailing, 8)
             }
 
             InputRowView(title: "誕生日") {
                 DatePicker("", selection: $viewModel.birthday, displayedComponents: .date)
+                    .disabled(viewModel.isLoading)
                     .environment(\.locale, Locale(identifier: "ja_JP"))
                     .labelsHidden()
             }
@@ -32,6 +34,7 @@ struct PersonInputView: View {
                             .tag(type)
                     }
                 }
+                .disabled(viewModel.isLoading)
             }
         }
     }


### PR DESCRIPTION
close #6 
- API通信のローディング 中
  - 「占う」ボタンのラベルをProgressViewに変更する
  - 触ることができるViewを.disable（非活性）にする
- エラー処理
  - バリデーションチェックをして、nameの要件(1文字以上128字未満)を満たしていなかったらアラート表示する
  - httpでエラーがあった場合、アラート表示する